### PR TITLE
added nil guard for share metadata in Meta function

### DIFF
--- a/_extensions/social-share/social-share.lua
+++ b/_extensions/social-share/social-share.lua
@@ -10,6 +10,9 @@ local function ensureHtmlDeps()
 end
 
 function Meta(m)
+    if m.share == nil then
+        return
+    end
     ensureHtmlDeps()
     local share_start = '<div class= "page-columns page-rows-contents page-layout-article"><div class="social-share">'
     if m.share.divclass then


### PR DESCRIPTION
## Problem
When `social-share` is used as a global filter (e.g. in `_format.yml`), the extension crashes on any page that doesn't include `share:` frontmatter. The Lua filter attempts to access `m.share.permalink` without checking if `m.share` exists.
## Fix
Add an early return in `Meta()` when `m.share` is `nil`, so the extension silently skips pages without share config.
## Reproduction
1. Add `social-share` to `filters` in a Quarto website's format config (applies to all pages)
2. Add `share:` frontmatter to some but not all pages
3. `quarto render` — crashes on pages without `share:` with a Lua error accessing a nil field
## Before / After
**Before:** `attempt to index a nil value (field 'permalink')` on pages without `share:` metadata
**After:** Pages without `share:` are silently skipped; pages with `share:` render share buttons as expected