### PR TITLE
feat: update Twitter share link and Icon to X.com

### DIFF
--- a/_extensions/social-share/social-share.css
+++ b/_extensions/social-share/social-share.css
@@ -32,12 +32,12 @@
 }
 
 .social-share a.twitter {
-    border-color: #1DA1F2;
-    color: #1DA1F2;
+    border-color: #000;
+    color: #000;
 }
 
 .social-share a.twitter:hover {
-    background: #1DA1F2;
+    background: #000;
     color: white;
 }
 

--- a/_extensions/social-share/social-share.lua
+++ b/_extensions/social-share/social-share.lua
@@ -30,9 +30,9 @@ function Meta(m)
     end
     if m.share.twitter then
         share_text = share_text ..
-            '<a href="https://twitter.com/share?url=' ..
+            '<a href="https://x.com/intent/post?url=' ..
             share_url ..
-            '&text=' .. post_title .. '" target="_blank" class="twitter"><i class="fab fa-twitter fa-fw fa-lg"></i></a>'
+            '&text=' .. post_title .. '" target="_blank" class="twitter"><i class="fa-brands fa-x-twitter fa-fw fa-lg"></i></a>'
     end
     if m.share.linkedin then
         share_text = share_text ..


### PR DESCRIPTION
## Summary
Updates the Twitter share button to reflect the X rebrand (July 2023): new icon, brand colors, and share endpoint.
## Changes
- **Icon**: `fab fa-twitter` → `fa-brands fa-x-twitter`
- **Brand color**: `#1DA1F2` (Twitter blue) → `#000` (X black)
- **Share URL**: `twitter.com/share` → `x.com/intent/post`
## Testing
- Built a Quarto website with the updated extension — `quarto render` succeeds with no errors
- Verified share button renders with the X icon and correct black color
- Verified `x.com/intent/post?url=...&text=...` link opens the compose dialog correctly